### PR TITLE
removed delete button for job and dataset tabs

### DIFF
--- a/web/src/components/datasets/DatasetDetailPage.tsx
+++ b/web/src/components/datasets/DatasetDetailPage.tsx
@@ -178,7 +178,7 @@ const DatasetDetailPage: FunctionComponent<IProps> = (props) => {
             </Box>
           </Box>
           <Box display={'flex'} alignItems={'center'}>
-            <Box mr={1}>
+            {/* <Box mr={1}>
               <Button
                 variant='outlined'
                 size={'small'}
@@ -205,7 +205,7 @@ const DatasetDetailPage: FunctionComponent<IProps> = (props) => {
                   props.dialogToggle('')
                 }}
               />
-            </Box>
+            </Box> */}
             <IconButton onClick={() => setSearchParams({})}>
               <CloseIcon fontSize={'small'} />
             </IconButton>

--- a/web/src/components/jobs/JobDetailPage.tsx
+++ b/web/src/components/jobs/JobDetailPage.tsx
@@ -179,7 +179,7 @@ const JobDetailPage: FunctionComponent<IProps> = (props) => {
             )}
           </Box>
           <Box display={'flex'} alignItems={'center'}>
-            <Box mr={1}>
+            {/* <Box mr={1}>
               <Button
                 variant='outlined'
                 size={'small'}
@@ -206,7 +206,7 @@ const JobDetailPage: FunctionComponent<IProps> = (props) => {
                   props.dialogToggle('')
                 }}
               />
-            </Box>
+            </Box> */}
             <Box mr={1}>
               <Button
                 size={'small'}


### PR DESCRIPTION
Fix #1 
I removed the delete buttons in the job and dataset tabs; 

sidenote: when I added mock data to create jobs, the mock data persisted even after I re-ran the app in a new docker container. 
